### PR TITLE
css refers to "none" URL

### DIFF
--- a/ckanext/c195/less/variables.less
+++ b/ckanext/c195/less/variables.less
@@ -5,7 +5,7 @@
 @anaeeSecondaryColor: #f3f3f3;
 @anaeeNotificationColor:#197f54;
 
-@bgPath: 'none';
+@bgPath: e("");
 @layoutFontFamily: 'montserratregular', georgia, times, serif;
 
 @mastheadBackgroundColor: @anaeeBackgroundColor;


### PR DESCRIPTION
Every time any CKAN page with the c195 customization is called, a 404 is returned when looking for base/css/none

Fix, changing @bgPath less var
